### PR TITLE
daily Issued & Burned entities added

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -438,7 +438,6 @@ export function handleIssuedSynths(event: IssuedEvent): void {
     if (dailyIssuedEntity == null) {
       dailyIssuedEntity = new DailyIssued(dayId);
       dailyIssuedEntity.value = event.params.value;
-      dailyIssuedEntity.timestamp = event.block.timestamp;
     } else {
       dailyIssuedEntity.value = dailyIssuedEntity.value + event.params.value;
     }
@@ -531,7 +530,6 @@ export function handleBurnedSynths(event: BurnedEvent): void {
     if (dailyBurnedEntity == null) {
       dailyBurnedEntity = new DailyBurned(dayId);
       dailyBurnedEntity.value = event.params.value;
-      dailyBurnedEntity.timestamp = event.block.timestamp;
     } else {
       dailyBurnedEntity.value = dailyBurnedEntity.value + event.params.value;
     }

--- a/subgraphs/synthetix.graphql
+++ b/subgraphs/synthetix.graphql
@@ -58,6 +58,20 @@ type SynthHolder @entity {
   balanceOf: BigInt!
 }
 
+type DailyIssued @entity {
+  id: ID!
+  value: BigInt!
+  totalDebt: BigInt!
+  timestamp: BigInt!
+}
+
+type DailyBurned @entity {
+  id: ID!
+  value: BigInt!
+  totalDebt: BigInt!
+  timestamp: BigInt!
+}
+
 # Issued tracks this event from various Synth.sol instances
 type Issued @entity {
   id: ID!
@@ -66,7 +80,6 @@ type Issued @entity {
   source: String!
   timestamp: BigInt!
   gasPrice: BigInt!
-  totalIssuedSUSD: BigInt
   block: BigInt!
 }
 
@@ -78,7 +91,6 @@ type Burned @entity {
   source: String!
   timestamp: BigInt!
   gasPrice: BigInt!
-  totalIssuedSUSD: BigInt
   block: BigInt!
 }
 

--- a/subgraphs/synthetix.graphql
+++ b/subgraphs/synthetix.graphql
@@ -62,14 +62,12 @@ type DailyIssued @entity {
   id: ID!
   value: BigInt!
   totalDebt: BigInt!
-  timestamp: BigInt!
 }
 
 type DailyBurned @entity {
   id: ID!
   value: BigInt!
   totalDebt: BigInt!
-  timestamp: BigInt!
 }
 
 # Issued tracks this event from various Synth.sol instances


### PR DESCRIPTION
I just used a different approach because the initial solution wasn't good enough. It was too much data to download on the FE. So this PR adds `DailyIssued` and `DailyBurned` entities which are aggregates for each day.

I've deployed it to my personal subgraph to see if Michael is happy with it. Let's merge it when we are sure the solution is good enough.