### PR TITLE
Shell shorts fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
 network=$1
 subgraph=$2
-networks=( mainnet optimism-mainnet kovan optimism-kovan )
+networks='mainnet optimism-mainnet kovan optimism-kovan'
+
+GRAPH=${GRAPH:-graph}
+
+# only need to run the same codegen once for all networks
+SNX_NETWORK=mainnet $GRAPH codegen subgraphs/$subgraph.js -o generated/subgraphs/$subgraph
 
 if [ "all" == $network ]; then
-    for i in "${networks[@]}"
-    do
-        SNX_NETWORK=$i graph codegen subgraphs/$subgraph.js -o generated/subgraphs/$subgraph
-        SNX_NETWORK=$i graph build subgraphs/$subgraph.js -o build/$i/subgraphs/$subgraph
+    for i in $networks; do
+	echo "building $i"
+        SNX_NETWORK=$i $GRAPH build subgraphs/$subgraph.js -o build/$i/subgraphs/$subgraph
     done
 else
-    SNX_NETWORK=$network graph codegen subgraphs/$subgraph.js -o generated/subgraphs/$subgraph
-    SNX_NETWORK=$network graph build subgraphs/$subgraph.js -o build/$network/subgraphs/$subgraph
+    SNX_NETWORK=$network $GRAPH build subgraphs/$subgraph.js -o build/$network/subgraphs/$subgraph
 fi

--- a/build.sh
+++ b/build.sh
@@ -10,9 +10,10 @@ SNX_NETWORK=mainnet $GRAPH codegen subgraphs/$subgraph.js -o generated/subgraphs
 
 if [ "all" == $network ]; then
     for i in $networks; do
-	echo "building $i"
+	echo "building $subgraph $i"
         SNX_NETWORK=$i $GRAPH build subgraphs/$subgraph.js -o build/$i/subgraphs/$subgraph
     done
 else
+    echo "building $subgraph $network"
     SNX_NETWORK=$network $GRAPH build subgraphs/$subgraph.js -o build/$network/subgraphs/$subgraph
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 network=$1
 subgraph=$2
-networks=( mainnet optimism-mainnet kovan optimism-kovan )
+networks='mainnet optimism-mainnet kovan optimism-kovan'
+
+GRAPH=${GRAPH:-graph}
 
 if [ "all" == $network ]; then
-    for i in "${networks[@]}"
-    do
-        graph deploy build/$i/$subgraph/subgraph.yaml
+    for i in $networks; do
+        echo "deploying $i"
+        $GRAPH deploy build/$i/$subgraph/subgraph.yaml
     done
 else
-    graph deploy build/$network/$subgraph/subgraph.yaml
+    $GRAPH deploy build/$network/$subgraph/subgraph.yaml
 fi

--- a/package.json
+++ b/package.json
@@ -11,11 +11,10 @@
   "scripts": {
     "lint": "eslint .",
     "prepare-abis": "node prepare-abis",
-    "build-one": "npm run prepare-abis && ./build.sh mainnet synthetix-rates",
-    "deploy-one": "./deploy.sh mainnet synthetix-rates",
-    "codegen-all": "for f in subgraphs/*.js; do SNX_NETWORK=mainnet graph codegen $f -o generated/${f%.js}; done",
-    "build-all": "for f in subgraphs/*.js; do SNX_NETWORK=mainnet graph build $f -o build/$SNX_NETWORK/${f%.js}; done",
-    "deploy-all": "for f in subgraphs/*.js; do graph deploy build/$SNX_NETWORK/${f%.js}/subgraph.yaml; done",
+    "build": "npm run prepare-abis && ./build.sh",
+    "deploy": "./deploy.sh",
+    "build-all": "for f in subgraphs/*.js; do ./build.sh all $(basename ${f%.js}); done",
+    "deploy-all": "for f in subgraphs/*.js; do ./deploy.sh all $(basename ${f%.js}); done",
     "prepare": "husky install"
   },
   "lint-staged": {

--- a/subgraphs/utils/network.js
+++ b/subgraphs/utils/network.js
@@ -11,8 +11,10 @@ function getReleaseInfo(file) {
 
   if (net === 'mainnet' || net === 'kovan') {
     return require('synthetix/publish/deployed/' + net + '/' + file);
-  } else if (net === 'optimism-kovan' || net === 'optimism-mainnet') {
-    return require('synthetix/publish/deployed/' + +'/' + file);
+  } else if (net === 'optimism-mainnet') {
+    return require('synthetix/publish/deployed/mainnet-ovm/' + file);
+  } else if (net === 'optimism-kovan') {
+    return require('synthetix/publish/deployed/kovan-ovm/' + file);
   }
 }
 


### PR DESCRIPTION
fix shell shorts
    
* allows overriding command to modified graph executable with `GRAPH=`
* runs all deployments
    
still remaining:
* test deploy is the way we want it
    
example testing command (adjust graph path to your actual):
    
```
GRAPH=../graph-cli/bin/graph npm run build all synthetix
```

/hours 1