### PR TITLE
WIP: local-ovm

### DIFF
--- a/mustache/templates/exchanger/contracts.js
+++ b/mustache/templates/exchanger/contracts.js
@@ -1,3 +1,52 @@
+
+const snx = require('synthetix')
+
+const contractsToLoad = {
+  'Exchanger': { type: 'exchanger', version: 0 },
+  'ProxyERC20': { type: 'synthetix', target: 'Synthetix', version: 0 }
+}
+
+const filterContractsToLoad = name => !!contractsToLoad[name]
+
+const exports2 = Object.values(
+  snx.getVersions({
+    network: 'mainnet',
+  })
+)
+.filter(version => {
+  if(!version.block) {
+    console.error(version.tag + ' is missing `block`')
+    return false
+  }
+  return true
+})
+.map(({ contracts, block }) => {
+  // Filter only contracts we track.
+  return Object.entries(contracts)
+    .filter(([contractName,]) => !!contractsToLoad[contractName])
+    .map(([ contractName, contract ]) => {
+      const { address } = contract
+
+      let info = contractsToLoad[contractName]
+      let name = info.target ? info.target : contractName
+      if (info.version > 0) {
+        name += `_v${info.version}`
+      }
+      info.version += 1
+
+      return {
+        prod: block,
+        test: null,
+        type: info.type,
+        name: `${name}`,
+        address: `'${address}'`,
+      }
+    })
+})
+.flat()
+
+// console.log(exports2)
+
 module.exports = [
   {
     prod: 10557958,


### PR DESCRIPTION
This is a WIP first pass of getting a local graph node setup, that can load the locally deployed artifacts using the `synthetix` package. 

The ideal workflow is:

 1. Pull latest synthetix `develop` branch. Deploy to the local chain.
 2. `npm link synthetix` into this repo, thus importing the local contract artifacts.
 3. Generate subgraph manifests (.yaml's), whose addresses are loaded depending on environment.
 4. `codegen` + `build`
 5. Deploy to local graph node.

Epic: https://github.com/Synthetixio/issues/issues/209