### PR TITLE
tracking of global debt status

### DIFF
--- a/subgraphs/synthetix.graphql
+++ b/subgraphs/synthetix.graphql
@@ -39,6 +39,28 @@ type SNXHolder @entity {
   mints: BigInt
 }
 
+# Global historical debt
+type DebtState @entity {
+  # debt entry index
+  id: ID!
+
+  # time at which these values are recorded
+  timestamp: BigInt!
+
+  # representation of total amount of debt issued over time. increases or
+  # decreases proportionally whenever synths are minted/burned
+  debtEntry: BigDecimal!
+
+  # current value of all issued synths which this debt pool is responsible
+  # for. fluctuates based on the synth breakdown of the system * exchange
+  # rates
+  totalIssuedSynths: BigDecimal!
+
+  # totalIssuedSynths / debtEntry
+  # useful for tracking debt over time
+  debtRatio: BigDecimal!
+}
+
 # A historical debt tracker
 type DebtSnapshot @entity {
   id: ID!

--- a/subgraphs/synthetix.yaml
+++ b/subgraphs/synthetix.yaml
@@ -106,6 +106,8 @@ dataSources:
       eventHandlers:
         - event: TargetUpdated(address)
           handler: handleProxyTargetUpdated
+      blockHandlers:
+        - handler: handleBlock
 
   #  Handle Transfer on current, but deprecated, ProxysUSD
   - kind: ethereum/contract

--- a/subgraphs/synthetix.yaml
+++ b/subgraphs/synthetix.yaml
@@ -137,6 +137,8 @@ dataSources:
           file: ../abis/AddressResolver.json
         - name: SynthetixState
           file: ../abis/SynthetixState.json
+        - name: Issuer
+          file: ../abis/Issuer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransferSynth
@@ -175,6 +177,8 @@ dataSources:
           file: ../abis/AddressResolver.json
         - name: SynthetixState
           file: ../abis/SynthetixState.json
+        - name: Issuer
+          file: ../abis/Issuer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransferSynth
@@ -213,6 +217,8 @@ dataSources:
           file: ../abis/AddressResolver.json
         - name: SynthetixState
           file: ../abis/SynthetixState.json
+        - name: Issuer
+          file: ../abis/Issuer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransferSynth
@@ -251,6 +257,8 @@ dataSources:
           file: ../abis/AddressResolver.json
         - name: SynthetixState
           file: ../abis/SynthetixState.json
+        - name: Issuer
+          file: ../abis/Issuer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransferSynth
@@ -289,6 +297,8 @@ dataSources:
           file: ../abis/AddressResolver.json
         - name: SynthetixState
           file: ../abis/SynthetixState.json
+        - name: Issuer
+          file: ../abis/Issuer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransferSynth
@@ -326,6 +336,8 @@ dataSources:
           file: ../abis/AddressResolver.json
         - name: SynthetixState
           file: ../abis/SynthetixState.json
+        - name: Issuer
+          file: ../abis/Issuer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransferSynth

--- a/subgraphs/synthetix.yaml
+++ b/subgraphs/synthetix.yaml
@@ -137,8 +137,6 @@ dataSources:
           file: ../abis/AddressResolver.json
         - name: SynthetixState
           file: ../abis/SynthetixState.json
-        - name: Issuer
-          file: ../abis/Issuer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransferSynth
@@ -177,8 +175,6 @@ dataSources:
           file: ../abis/AddressResolver.json
         - name: SynthetixState
           file: ../abis/SynthetixState.json
-        - name: Issuer
-          file: ../abis/Issuer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransferSynth
@@ -217,8 +213,6 @@ dataSources:
           file: ../abis/AddressResolver.json
         - name: SynthetixState
           file: ../abis/SynthetixState.json
-        - name: Issuer
-          file: ../abis/Issuer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransferSynth
@@ -257,8 +251,6 @@ dataSources:
           file: ../abis/AddressResolver.json
         - name: SynthetixState
           file: ../abis/SynthetixState.json
-        - name: Issuer
-          file: ../abis/Issuer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransferSynth
@@ -297,8 +289,6 @@ dataSources:
           file: ../abis/AddressResolver.json
         - name: SynthetixState
           file: ../abis/SynthetixState.json
-        - name: Issuer
-          file: ../abis/Issuer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransferSynth
@@ -336,8 +326,6 @@ dataSources:
           file: ../abis/AddressResolver.json
         - name: SynthetixState
           file: ../abis/SynthetixState.json
-        - name: Issuer
-          file: ../abis/Issuer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransferSynth


### PR DESCRIPTION
adds a new entity `DebtState` which will allow for the tracking and charting of debt pool fluctuations
on a global level. currently there is no easy mechanism to
analyze this historically so this is an excellent use of the graph.

when this merge, a historical debt responsibility graph will be added to stats. It might also be useful
to add this data to staking.

testing subgraph deployment: https://thegraph.com/explorer/subgraph/killerbyte/synthetix?version=pending

/hours 3