### PR TITLE
fix / account for LoanClosedByRepayment event in shorts subgraph

### DIFF
--- a/abis/CollateralShortOVM.json
+++ b/abis/CollateralShortOVM.json
@@ -1,0 +1,1225 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "contract ICollateralManager",
+        "name": "_manager",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_resolver",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_collateralKey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minCratio",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minCollateral",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "name",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "destination",
+        "type": "address"
+      }
+    ],
+    "name": "CacheUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "canOpenLoans",
+        "type": "bool"
+      }
+    ],
+    "name": "CanOpenLoansUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountDeposited",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateralAfter",
+        "type": "uint256"
+      }
+    ],
+    "name": "CollateralDeposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountWithdrawn",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateralAfter",
+        "type": "uint256"
+      }
+    ],
+    "name": "CollateralWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "issueFeeRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "IssueFeeRateUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "LoanClosed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "liquidator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountLiquidated",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateralLiquidated",
+        "type": "uint256"
+      }
+    ],
+    "name": "LoanClosedByLiquidation",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountRepaid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateralAfter",
+        "type": "uint256"
+      }
+    ],
+    "name": "LoanClosedByRepayment",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "currency",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "issuanceFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "LoanCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "LoanDrawnDown",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "liquidator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountLiquidated",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateralLiquidated",
+        "type": "uint256"
+      }
+    ],
+    "name": "LoanPartiallyLiquidated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "repayer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountRepaid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountAfter",
+        "type": "uint256"
+      }
+    ],
+    "name": "LoanRepaymentMade",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minCollateral",
+        "type": "uint256"
+      }
+    ],
+    "name": "MinCollateralUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerNominated",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "rewardsContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "synth",
+        "type": "bytes32"
+      }
+    ],
+    "name": "addRewardsContracts",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "_synthNamesInResolver",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_synthKeys",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "addSynths",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "_synthNamesInResolver",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_synthKeys",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "areSynthsAndCurrenciesSet",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "canOpenLoans",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "close",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "closeWithCollateral",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "collateralKey",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "collateralRatio",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "cratio",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "principal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "draw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "principal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "getShortAndCollateral",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "principal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isResolverCached",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "issueFeeRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "liquidate",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "liquidationAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "liqAmount",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "loans",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address payable",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "currency",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "short",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "accruedInterest",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "interestIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastInteraction",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "manager",
+    "outputs": [
+      {
+        "internalType": "contract ICollateralManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "currency",
+        "type": "bytes32"
+      }
+    ],
+    "name": "maxLoan",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "minCollateral",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "minCratio",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "nominateNewOwner",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "nominatedOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "currency",
+        "type": "bytes32"
+      }
+    ],
+    "name": "open",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "rebuildCache",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "repay",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "principal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "repayWithCollateral",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "principal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "resolver",
+    "outputs": [
+      {
+        "internalType": "contract AddressResolver",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "resolverAddressesRequired",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "addresses",
+        "type": "bytes32[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_canOpenLoans",
+        "type": "bool"
+      }
+    ],
+    "name": "setCanOpenLoans",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_issueFeeRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "setIssueFeeRate",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_minCollateral",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMinCollateral",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "shortingRewards",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "synths",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "synthsByKey",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "principal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/shorts.ts
+++ b/src/shorts.ts
@@ -9,12 +9,8 @@ import {
   LoanPartiallyLiquidated as LoanPartiallyLiquidatedEvent,
   LoanClosedByLiquidation as LoanClosedByLiquidationEvent,
   LoanClosedByRepayment as LoanClosedByRepaymentEvent,
-  MinCratioRatioUpdated as MinCratioRatioUpdatedEvent,
   MinCollateralUpdated as MinCollateralUpdatedEvent,
   IssueFeeRateUpdated as IssueFeeRateUpdatedEvent,
-  MaxLoansPerAccountUpdated as MaxLoansPerAccountUpdatedEvent,
-  InteractionDelayUpdated as InteractionDelayUpdatedEvent,
-  ManagerUpdated as ManagerUpdatedEvent,
   CanOpenLoansUpdated as CanOpenLoansUpdatedEvent,
 } from '../generated/subgraphs/shorts/shorts_CollateralShort_0/CollateralShort';
 
@@ -58,8 +54,6 @@ function addContractData(
 ): ShortContract {
   let collateralShortContract = CollateralShortContract.bind(contractAddress);
   let issueFeeRate = collateralShortContract.try_issueFeeRate();
-  let maxLoans = collateralShortContract.try_maxLoansPerAccount();
-  let interactionDelay = collateralShortContract.try_interactionDelay();
 
   let shortContractEntity = ShortContract.load(contractAddress.toHex());
   if (shortContractEntity == null) {
@@ -76,9 +70,7 @@ function addContractData(
   }
   shortContractEntity.minCratio = collateralShortContract.minCratio();
   shortContractEntity.minCollateral = toDecimal(collateralShortContract.minCollateral());
-  shortContractEntity.maxLoansPerAccount = !maxLoans.reverted ? maxLoans.value : ZERO;
   shortContractEntity.issueFeeRate = toDecimal(!issueFeeRate.reverted ? issueFeeRate.value : ZERO);
-  shortContractEntity.interactionDelay = !interactionDelay.reverted ? interactionDelay.value : ZERO;
   shortContractEntity.manager = collateralShortContract.manager();
   shortContractEntity.canOpenLoans = collateralShortContract.canOpenLoans();
   shortContractEntity.save();
@@ -391,27 +383,6 @@ export function handleLoanClosedByRepayment(event: LoanClosedByRepaymentEvent): 
   shortEntity.save();
 }
 
-export function handleMinCratioRatioUpdatedsUSD(event: MinCratioRatioUpdatedEvent): void {
-  let shortContractEntity = loadContractData(
-    event.address,
-    event.transaction.hash.toHex(),
-    event.logIndex.toString(),
-    event.block.timestamp,
-    event.block.number,
-  );
-  shortContractEntity.minCratio = event.params.minCratio;
-  shortContractEntity.save();
-  saveContractLevelUpdate(
-    event.transaction.hash.toHex(),
-    event.logIndex.toString(),
-    'minCratio',
-    event.params.minCratio.toString(),
-    event.block.timestamp,
-    event.block.number,
-    shortContractEntity as ShortContract,
-  );
-}
-
 export function handleMinCollateralUpdatedsUSD(event: MinCollateralUpdatedEvent): void {
   let shortContractEntity = loadContractData(
     event.address,
@@ -448,69 +419,6 @@ export function handleIssueFeeRateUpdatedsUSD(event: IssueFeeRateUpdatedEvent): 
     event.logIndex.toString(),
     'issueFeeRate',
     event.params.issueFeeRate.toString(),
-    event.block.timestamp,
-    event.block.number,
-    shortContractEntity as ShortContract,
-  );
-}
-
-export function handleMaxLoansPerAccountUpdatedsUSD(event: MaxLoansPerAccountUpdatedEvent): void {
-  let shortContractEntity = loadContractData(
-    event.address,
-    event.transaction.hash.toHex(),
-    event.logIndex.toString(),
-    event.block.timestamp,
-    event.block.number,
-  );
-  shortContractEntity.maxLoansPerAccount = event.params.maxLoansPerAccount;
-  shortContractEntity.save();
-  saveContractLevelUpdate(
-    event.transaction.hash.toHex(),
-    event.logIndex.toString(),
-    'maxLoansPerAccount',
-    event.params.maxLoansPerAccount.toString(),
-    event.block.timestamp,
-    event.block.number,
-    shortContractEntity as ShortContract,
-  );
-}
-
-export function handleInteractionDelayUpdatedsUSD(event: InteractionDelayUpdatedEvent): void {
-  let shortContractEntity = loadContractData(
-    event.address,
-    event.transaction.hash.toHex(),
-    event.logIndex.toString(),
-    event.block.timestamp,
-    event.block.number,
-  );
-  shortContractEntity.interactionDelay = event.params.interactionDelay;
-  shortContractEntity.save();
-  saveContractLevelUpdate(
-    event.transaction.hash.toHex(),
-    event.logIndex.toString(),
-    'interactionDelay',
-    event.params.interactionDelay.toString(),
-    event.block.timestamp,
-    event.block.number,
-    shortContractEntity as ShortContract,
-  );
-}
-
-export function handleManagerUpdatedsUSD(event: ManagerUpdatedEvent): void {
-  let shortContractEntity = loadContractData(
-    event.address,
-    event.transaction.hash.toHex(),
-    event.logIndex.toString(),
-    event.block.timestamp,
-    event.block.number,
-  );
-  shortContractEntity.manager = event.params.manager;
-  shortContractEntity.save();
-  saveContractLevelUpdate(
-    event.transaction.hash.toHex(),
-    event.logIndex.toString(),
-    'manager',
-    event.params.manager.toHex(),
     event.block.timestamp,
     event.block.number,
     shortContractEntity as ShortContract,

--- a/src/shorts.ts
+++ b/src/shorts.ts
@@ -8,6 +8,7 @@ import {
   LoanDrawnDown as LoanDrawnDownEvent,
   LoanPartiallyLiquidated as LoanPartiallyLiquidatedEvent,
   LoanClosedByLiquidation as LoanClosedByLiquidationEvent,
+  LoanClosedByRepayment as LoanClosedByRepaymentEvent,
   MinCratioRatioUpdated as MinCratioRatioUpdatedEvent,
   MinCollateralUpdated as MinCollateralUpdatedEvent,
   IssueFeeRateUpdated as IssueFeeRateUpdatedEvent,
@@ -371,6 +372,23 @@ export function handleLoanClosedByLiquidationsUSD(event: LoanClosedByLiquidation
     event.block.timestamp,
     event.block.number,
   );
+}
+
+export function handleLoanClosedByRepayment(event: LoanClosedByRepaymentEvent): void {
+  let shortEntity = Short.load(event.params.id.toString());
+  if (shortEntity == null) {
+    log.error('trying to close a loan that does not exist with id: {} from txHash: {}', [
+      event.params.id.toString(),
+      event.transaction.hash.toHex(),
+    ]);
+    return;
+  }
+  shortEntity.isOpen = false;
+  shortEntity.closedAt = event.block.timestamp;
+  shortEntity.accruedInterestLastUpdateTimestamp = event.block.timestamp;
+  shortEntity.synthBorrowedAmount = toDecimal(BigInt.fromI32(0));
+  shortEntity.collateralLockedAmount = toDecimal(BigInt.fromI32(0));
+  shortEntity.save();
 }
 
 export function handleMinCratioRatioUpdatedsUSD(event: MinCratioRatioUpdatedEvent): void {

--- a/subgraphs/shorts.js
+++ b/subgraphs/shorts.js
@@ -42,7 +42,7 @@ getContractDeployments('CollateralShort').forEach((a, i) => {
         },
         {
           name: 'CollateralShort',
-          file: '../abis/CollateralShort.json',
+          file: '../abis/CollateralShortOVM.json',
         },
       ],
       eventHandlers: [
@@ -79,10 +79,6 @@ getContractDeployments('CollateralShort').forEach((a, i) => {
           handler: 'handleLoanClosedByLiquidationsUSD',
         },
         {
-          event: 'MinCratioRatioUpdated(uint256)',
-          handler: 'handleMinCratioRatioUpdatedsUSD',
-        },
-        {
           event: 'MinCollateralUpdated(uint256)',
           handler: 'handleMinCollateralUpdatedsUSD',
         },
@@ -91,25 +87,13 @@ getContractDeployments('CollateralShort').forEach((a, i) => {
           handler: 'handleIssueFeeRateUpdatedsUSD',
         },
         {
-          event: 'MaxLoansPerAccountUpdated(uint256)',
-          handler: 'handleMaxLoansPerAccountUpdatedsUSD',
-        },
-        {
-          event: 'InteractionDelayUpdated(uint256)',
-          handler: 'handleInteractionDelayUpdatedsUSD',
-        },
-        {
-          event: 'ManagerUpdated(address)',
-          handler: 'handleManagerUpdatedsUSD',
-        },
-        {
           event: 'CanOpenLoansUpdated(bool)',
           handler: 'handleCanOpenLoansUpdatedsUSD',
         },
         {
-          event: 'LoanClosedByRepayment(borrower, id, amount, collateral)',
+          event: 'LoanClosedByRepayment(indexed address,uint256,uint256,uint256)',
           handler: 'handleLoanClosedByRepayment',
-        }
+        },
       ],
     },
   });

--- a/subgraphs/shorts.js
+++ b/subgraphs/shorts.js
@@ -106,6 +106,10 @@ getContractDeployments('CollateralShort').forEach((a, i) => {
           event: 'CanOpenLoansUpdated(bool)',
           handler: 'handleCanOpenLoansUpdatedsUSD',
         },
+        {
+          event: 'LoanClosedByRepayment(borrower, id, amount, collateral)',
+          handler: 'handleLoanClosedByRepayment',
+        }
       ],
     },
   });

--- a/subgraphs/wrapper.js
+++ b/subgraphs/wrapper.js
@@ -176,6 +176,7 @@ if (getCurrentNetwork() == 'optimism') {
   let daiSource = clone(daiWrapper.source);
   daiSource.address = '0xad32aA4Bff8b61B4aE07E3BA437CF81100AF0cD7';
   daiWrapper.source = daiSource;
+  daiWrapper.source.startBlock = parseInt(process.env.SNX_START_BLOCK) || 0;
   manifest.push(daiWrapper);
 
   let ethWrapper = clone(wrapperTemplate);
@@ -183,6 +184,7 @@ if (getCurrentNetwork() == 'optimism') {
   let ethSource = clone(ethWrapper.source);
   ethSource.address = '0x6202A3B0bE1D222971E93AaB084c6E584C29DB70';
   ethWrapper.source = ethSource;
+  ethWrapper.source.startBlock = parseInt(process.env.SNX_START_BLOCK) || 0;
   manifest.push(ethWrapper);
 }
 


### PR DESCRIPTION
The `shorts` subgraph is currently not updating the status of a `Short` when the short has been closed via the `loanClosedByRepayment` method:

https://github.com/Synthetixio/synthetix/blob/develop/contracts/Collateral.sol#L377

i.e., the subgraph isn't listening for the `LoanClosedByRepayment` event:

https://github.com/Synthetixio/synthetix/blob/develop/contracts/Collateral.sol#L393

This PR adds both a listener and a handler to handle the aforementioned event.