### PR TITLE
Addresses error on Kovan deploy

### DIFF
--- a/src/global-debt.ts
+++ b/src/global-debt.ts
@@ -40,14 +40,13 @@ export function trackGlobalDebt(block: ethereum.Block): void {
 
     let debtStateEntity = new DebtState(timeSlot.toString());
 
+    let debtEntry = synthetixState.try_lastDebtLedgerEntry();
+    if (!debtEntry.reverted) {
+      debtStateEntity.debtEntry = toDecimal(debtEntry.value);
+      debtStateEntity.totalIssuedSynths = toDecimal(issuedSynths.value);
+      debtStateEntity.debtRatio = debtStateEntity.totalIssuedSynths.div(debtStateEntity.debtEntry);
+    }
     debtStateEntity.timestamp = block.timestamp;
-
-    // debt entry represents percentage ownership of the "first" snx staker. It must be inverted to make sense of issued/burnt
-    debtStateEntity.debtEntry = toDecimal(BigInt.fromI32(1), 0).div(toDecimal(synthetixState.lastDebtLedgerEntry()));
-
-    debtStateEntity.totalIssuedSynths = toDecimal(issuedSynths.value);
-
-    debtStateEntity.debtRatio = debtStateEntity.totalIssuedSynths.div(debtStateEntity.debtEntry);
     debtStateEntity.save();
   }
 }


### PR DESCRIPTION
To fix the following error when deploying to Kovan: `Mapping aborted at ~lib/@graphprotocol/graph-ts/chain/ethereum.ts, line 434, column 7, with message: Call reverted, probably because an assert or require in the contract failed, consider using try_lastDebtLedgerEntry to handle this in the mapping.`