### PR TITLE
[WIP] Fix SNX totalSupply

### DIFF
--- a/src/fragments/balances.ts
+++ b/src/fragments/balances.ts
@@ -96,8 +96,8 @@ function trackMintOrBurn(synthAddress: Address, value: BigDecimal): void {
       synth.totalSupply = toDecimal(synthBackContract.totalSupply());
     } else {
       synth.totalSupply = newSupply;
-      synth.save();
     }
+    synth.save();
   }
 }
 


### PR DESCRIPTION
Test deploy: https://thegraph.com/hosted-service/subgraph/noahlitvin/optimism-main?version=pending (Looking to see ~36MM totalSupply of SNX rather than ~30MM SNX once syncing completes.)