### PR TITLE
Use early return to be certain that trackMintOrBurn isn't called twice

### DIFF
--- a/src/fragments/balances.ts
+++ b/src/fragments/balances.ts
@@ -100,18 +100,25 @@ function trackMintOrBurn(synthAddress: Address, value: BigDecimal): void {
 
     synth.save();
   }
+  log.error('Synth is null even though we tried to create it', []);
 }
 
 export function handleTransferSynth(event: SynthTransferEvent): void {
   if (event.params.from.toHex() != ZERO_ADDRESS.toHex() && event.params.from != event.address) {
     trackSynthHolder(event.address, event.params.from, event.block.timestamp, toDecimal(event.params.value).neg());
-  } else {
-    trackMintOrBurn(event.address, toDecimal(event.params.value));
+    return;
   }
-
   if (event.params.to.toHex() != ZERO_ADDRESS.toHex() && event.params.to != event.address) {
     trackSynthHolder(event.address, event.params.to, event.block.timestamp, toDecimal(event.params.value));
-  } else {
-    trackMintOrBurn(event.address, toDecimal(event.params.value).neg());
+    return;
   }
+  if (event.params.from == event.address) {
+    trackMintOrBurn(event.address, toDecimal(event.params.value));
+    return;
+  }
+  if (event.params.to == event.address) {
+    trackMintOrBurn(event.address, toDecimal(event.params.value).neg());
+    return;
+  }
+  log.warning('Expected condition to handle all transfer events', []);
 }


### PR DESCRIPTION
I've synced optimism and I get different result when running this query on [my subgraph](https://thegraph.com/hosted-service/subgraph/bachstatter/optimism-balances) vs [synthetix one](https://thegraph.com/hosted-service/subgraph/synthetixio-team/optimism-main)
```
{

  synths(first: 1000, where:{symbol: "sETH"}) {
    id
    name
    symbol
    totalSupply
  }
}
```

Will now synch to on mainnet too and then see if the results with this change are aligned with Kalebs script